### PR TITLE
Make Docker deploy work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ TSBC-NC-AUAT.log
 data/
 .tsbc-nc-tmp/
 secrets/
+reports/
+requirements/secret.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+  software-properties-common \
+  vim \
+  && add-apt-repository ppa:jonathonf/python-3.6
+RUN apt-get update -y
+RUN apt-get install -y \
+  build-essential \
+  python3.6 \
+  python3.6-dev \
+  python3-pip \
+  python3.6-venv
+
+RUN python3.6 -m pip install pip --upgrade && \
+  python3.6 -m pip install wheel
+
+ENV PYTHONUNBUFFERED 1
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  alien \
+  libaio1 \
+  libaio-dev \
+  libxrender1 \
+  libfontconfig1 \
+  rpm2cpio \
+  cpio \
+  unzip \
+  mysql-client \
+  libsasl2-dev \
+  python-dev \
+  libldap2-dev \
+  libssl-dev \
+  git \
+  wget
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ARG requirements_abs_path=/src/auat/requirements.txt
+
+COPY requirements.txt /src/auat/requirements.txt
+COPY requirements/ /src/auat/requirements/
+RUN python3.6 -m venv /usr/lib/auatvenv
+RUN /usr/lib/auatvenv/bin/pip install --upgrade pip
+RUN /usr/lib/auatvenv/bin/pip install -r ${requirements_abs_path}
+
+RUN set -ex \
+    && groupadd --gid 333 --system auat \
+    && useradd --uid 333 --gid 333 --system auat
+
+ADD ./ /src/auat/
+WORKDIR /src/auat
+
+RUN set -ex \
+    && mkdir /var/log/auat/ \
+    && chown -R auat:auat /var/log/auat \
+    && chown -R auat:auat /src/auat \
+    && chown -R auat:auat /usr/lib/auatvenv
+
+USER auat
+
+ENTRYPOINT tail -f /dev/null

--- a/features/steps/generate_documents_steps.py
+++ b/features/steps/generate_documents_steps.py
@@ -48,9 +48,11 @@ def step_impl(context, output_type, template_key, context_path):
         'output_type': output_type,
         'template_key': template_key,
         'context_path': context_path,}
-    context.scenario.generate_document_response = (
-        context.user.dgs.generate_document(
-            template_key, context_path, output_type=output_type))
+    generate_document_response = context.user.dgs.generate_document(
+        template_key, context_path, output_type=output_type)
+    generate_document_response['url'] = utils.internalize_url(
+        generate_document_response['url'])
+    context.scenario.generate_document_response = generate_document_response
 
 
 # Thens
@@ -71,7 +73,7 @@ def step_impl(context):
         f'Failed to download generated document'
         f' {context.scenario.generate_document_response["file_name"]}'
         f' from url'
-        f' {context.scenario.generate_document_response["url"]}.'
+        f' {url}.'
         f' There is no file at the expected download path'
         f' {context.scenario.downloaded_doc_path}.')
 

--- a/features/steps/send_emails_steps.py
+++ b/features/steps/send_emails_steps.py
@@ -58,6 +58,8 @@ def step_impl(context):
     corresponding document from the MDS, and then assert that the two HTML
     documents are identical.
     """
+    if os.getenv('SKIP_EMAIL_DELIVERY_VERIFICATION') == 'true':
+        return
     from_email_client = None
     sleep = 1
     for i in range(3):

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -1,0 +1,9 @@
+import os
+
+
+def internalize_url(url):
+    mapping = os.getenv('URL_INTERNALIZE_MAPPING')
+    if mapping:
+        k, v = mapping.split('|')
+        return url.replace(k, v)
+    return url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,1 @@
-behave>=1.0
-git+https://jdunham@bitbucket.safetyauthority.ca/scm/nc/document-generator-service.git@DG-3-grouping-permit-templates-update
-git+https://jdunham@bitbucket.safetyauthority.ca/scm/ess/email-sending-service-api.git@ESS-8-fix-pip-installability
-git+https://jdunham@bitbucket.safetyauthority.ca/scm/des/delivery-service-api.git@DES-5-fix-pip-installability
-google-api-python-client==1.7.8
-google-auth-httplib2==0.0.3
-google-auth-oauthlib==0.2.0
-htmlmin==0.1.12
-mail-parser==3.9.2
-requests==2.21.0
-slate3k==0.5.3
-tox==3.7.0
+-r requirements/production.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,10 @@
+behave>=1.0
+google-api-python-client==1.7.8
+google-auth-httplib2==0.0.3
+google-auth-oauthlib==0.2.0
+htmlmin==0.1.12
+junit2html==22
+mail-parser==3.9.2
+requests==2.21.0
+slate3k==0.5.3
+tox==3.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,0 +1,14 @@
+# Pro-tip: Try not to put anything here. There should be no dependency in
+# production that isn't in development.
+-r base.txt
+
+# These ARE put here because this is a private BitBucket repo that cannot be
+# accessed outside of trusted networks. A developer installing the TSBC-NC-AUAT
+# might want to install the other dependencies but choose another method for
+# installing the following ones:
+
+git+https://jdunham@bitbucket.safetyauthority.ca/scm/nc/document-generator-service.git@develop
+git+https://jdunham@bitbucket.safetyauthority.ca/scm/ess/email-sending-service-api.git@develop
+git+https://jdunham@bitbucket.safetyauthority.ca/scm/des/delivery-service-api.git@develop
+
+# TODO: remove the "jdunham" from the above.


### PR DESCRIPTION
- Add Dockerfile
- Split Python requirements to facilitate installation of dependencies behind
  authentication walls.
- Allow for URL "internalization" via environment variables.
- Allow skipping of email delivery verification (via
  SKIP_EMAIL_DELIVERY_VERIFICATION env var).